### PR TITLE
Let logs go to docker rather than to terminal.

### DIFF
--- a/xstartup.sh
+++ b/xstartup.sh
@@ -24,4 +24,4 @@ fluxbox &
 x11vnc -display $DISPLAY -N -shared -forever &
 
 # Start the selenium server
-xterm -maximized -e java -jar /root/selenium-server/selenium-server-standalone.jar -ensureCleanSession -trustAllSSLCertificates
+java -jar /root/selenium-server/selenium-server-standalone.jar -ensureCleanSession -trustAllSSLCertificates


### PR DESCRIPTION
Logs from selenium used to go to the terminal. That means that if there was something wrong with the selenium, we had to connect the VNC to inspect. The container can be destroyed by wharf any time when some problem with it is detected, so the errors may get lost. But it is easy to do `docker logs -f some_container_id` to stream the logs to the devel for observation. Much easier than ... i don't know, recording the VNC? Therefore letting the selenium logs go to the docker seems like better option in this regard.