### PR TITLE
[RFR] replacement of xvfb with xtightervncserver

### DIFF
--- a/Dockerfile.sel_base_fc28
+++ b/Dockerfile.sel_base_fc28
@@ -1,6 +1,0 @@
-FROM fedora:28
-RUN rpm -ivh http://linuxdownload.adobe.com/adobe-release/adobe-release-x86_64-1.0-1.noarch.rpm
-RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-adobe-linux
-RUN yum install -y x11vnc wget fluxbox bzip2 xterm nano xorg-x11-server-Xvfb net-tools dbus-glib gtk2 java-1.8.0-openjdk flash-plugin alsa-plugins-pulseaudio libcurl unzip xdg-utils redhat-lsb GConf2 libXScrnSaver xorg-x11-fonts-ISO8859-1-75dpi xorg-x11-fonts-ISO8859-1-100dpi dejavu* openssh-server gtk3
-RUN mkdir -p /.mozilla/plugins
-RUN ln -s /usr/lib64/flash-plugin/libflashplayer.so /.mozilla/plugins/libflashplayer.so

--- a/Dockerfile.sel_base_fc29
+++ b/Dockerfile.sel_base_fc29
@@ -1,0 +1,31 @@
+FROM fedora:29
+RUN rpm -ivh http://linuxdownload.adobe.com/adobe-release/adobe-release-x86_64-1.0-1.noarch.rpm
+RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-adobe-linux
+RUN dnf -y update && \
+    dnf install -y wget \
+                       vim \
+                       fluxbox \
+                       bzip2 \
+                       xterm \
+                       nano \
+                       net-tools \
+                       dbus-glib gtk2 \
+                       java-1.8.0-openjdk \
+                       flash-plugin \
+                       alsa-plugins-pulseaudio \
+                       libcurl \
+                       unzip \
+                       xdg-utils \
+                       redhat-lsb \
+                       gtk3 \
+                       tigervnc-server \
+                       dejavu-sans-fonts \
+                       dejavu-serif-fonts \
+                       xdotool && \
+    dnf clean all
+
+
+
+RUN mkdir -p /.mozilla/plugins && \
+    mkdir -p ~/.cache/dconf && \
+    ln -s /usr/lib64/flash-plugin/libflashplayer.so /.mozilla/plugins/libflashplayer.so

--- a/Dockerfile.stable
+++ b/Dockerfile.stable
@@ -1,12 +1,16 @@
-FROM cfmeqe/sel_base_fc28
+FROM cfmeqe/sel_base_fc29
 
 #TODO: figure why user 0 was needed
 USER 0
 
 ENV CHROME_DRIVER_VERSION 2.35
 ENV SELENIUM_VERSION 3.14.0
-ENV FIREFOX_VERSION 60.2.2esr
+ENV FIREFOX_VERSION 60.3.0esr
 ENV GECKODRIVER_VERSION v0.20.1
+
+# runtime
+EXPOSE 4444
+EXPOSE 5999
 
 # chrome
 ADD https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm \
@@ -20,9 +24,7 @@ ADD http://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriv
 RUN mkdir -p /root/chrome-driver &&\
     unzip -d /root/chrome-driver/ /root/chrome-driver/chromedriver_linux64.zip &&\
     rm -f /root/chrome-driver/chromedriver_linux64.zip
-# xstartup
-ADD ./xstartup.sh /xstartup.sh
-RUN chmod 775 /xstartup.sh
+
 # selenium
 # TODO: make better url scheme
 ADD http://selenium-release.storage.googleapis.com/3.14/selenium-server-standalone-$SELENIUM_VERSION.jar \
@@ -36,10 +38,16 @@ ADD https://github.com/mozilla/geckodriver/releases/download/$GECKODRIVER_VERSIO
 
 RUN tar -C /root/ -xjvf /root/firefox.tar.bz2 && rm -f /root/firefox.tar.bz2
 RUN tar -C /root/firefox/ -xvf /root/gecko.tar.gz && rm -f /root/gecko.tar.gz
-RUN mkdir -p ~/.cache/dconf
 
-# runtime
-EXPOSE 4444
-EXPOSE 5999
+# Add the xstartup file into the image and add config.
+RUN mkdir /root/.vnc
+ADD ./vncxstartup /root/.vnc/xstartup
+ADD ./vncconfig /root/.vnc/config
+RUN chmod 755 /root/.vnc/xstartup
+# get rid of error in vncserver logs
+RUN touch $HOME/.Xauthority && touch /allout.txt
 
-CMD ["/bin/bash", "/xstartup.sh"]
+ADD ./xstartup.sh /xstartup.sh
+RUN chmod 755 /xstartup.sh
+
+ENTRYPOINT ["/xstartup.sh"]

--- a/build_all.bash
+++ b/build_all.bash
@@ -1,7 +1,7 @@
 #!bin/bash
 
 BUILDS=(
-	sel_base_fc28
+	sel_base_fc29
 	stable
 )
 

--- a/vncconfig
+++ b/vncconfig
@@ -1,0 +1,4 @@
+securitytypes=none
+geometry=1280x1024
+depth=16
+alwaysshared

--- a/vncxstartup
+++ b/vncxstartup
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+unset SESSION_MANAGER
+unset DBUS_SESSION_BUS_ADDRESS
+
+[ -x /etc/vnc/xstartup ] && exec /etc/vnc/xstartup
+[ -r $HOME/.Xresources ] && xrdb $HOME/.Xresources
+
+xsetroot -solid grey
+fluxbox &
+sleep 5
+xterm -maximized -e "tail -f /allout.txt" -ls -title "$VNCDESKTOP Desktop" &
+

--- a/xstartup.sh
+++ b/xstartup.sh
@@ -1,31 +1,9 @@
 #!/bin/sh
 
-# Change rootpw
-echo $PASS | passwd --stdin root
-
-# Set up the environment so selenium can find everything it might want (namely chrome and chromedriver)
-/usr/sbin/ssh-keygen -A
-/usr/sbin/sshd
-
-# Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1286787
-if [ ! -f /etc/machine-id ]; then
-  echo "7f496b3288e64931bd91bf723697e19c" > /etc/machine-id
-fi
-
-# Start Xvfb and x11vnc
 export DISPLAY=:99
 export PATH="/usr/bin:/root/firefox:/root/chrome-driver:$PATH"
-export SSLKEYLOGFILE="/root/sslkeyfile.log"
 
-Xvfb $DISPLAY -shmem -screen 0 '1280x1024x16' -ac +extension RANDR &
-sleep 5
-
-fluxbox &
-x11vnc -display $DISPLAY -N -shared -forever &
-
-touch allout.txt
-
-xterm -maximized -e tail -f allout.txt &
+vncserver ${DISPLAY} -Log *:stderr:100 >> /allout.txt
 
 # Start the selenium server
-java -jar /root/selenium-server/selenium-server-standalone.jar 2>&1 | tee -a allout.txt
+java -jar /root/selenium-server/selenium-server-standalone.jar 2>&1 | tee -a /allout.txt


### PR DESCRIPTION
Current container has a few bugs which need to be sorted out.
One of issues Xvfb often crashes when user does some activities thru vnc.

In addition, this PR is going to update image to fedora 29 and FF to the latest ESR 60.3.0.